### PR TITLE
Allow to benchmark different approaches

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,29 @@ or as environment variables passed to `docker-compose`:
 NUM_CONSUMERS=100 docker-compose up
 ```
 
+### Approaches
+
+#### Multiple filter subjects
+
+This benchmark defaults to the approach where each client creates one consumer that has multiple filter subjects. This minimizes the number of consumers and it minimizes network traffic. Each client only receives the data it needs, the filtering is done on the NATS server.
+
+#### Many consumers
+
+An alternative approach is to let each client install many consumers, each with only a single filter subject. This also results in each client only receiving the data it needs, again the filtering is done on the NATS server. However the number of consumers is much larger. You can also benchmark this approach:
+
+```shell
+APPROACH=many-consumers docker-compose up
+```
+
+#### Wildcard subscription
+
+Another alternative is to let each client install a single consumer using a wildcard subscription that matches all messages. Each client will receive all the data, also the data it doesn't actually need. This results in much higher network traffic, the filtering then needs to be done on the client side. You can also benchmark this approach:
+
+```shell
+APPROACH=wildcard docker-compose up
+```
+
+
 ## Profiling
 
 The `pprof` container obtains a profile from the NATS server under test. If your benchmark runs longer than 30 seconds, or if you wait long enough at the end of the benchmark, a `nats.profile` will appear in the `profiles`

--- a/client/config.go
+++ b/client/config.go
@@ -2,10 +2,13 @@ package client
 
 import (
 	"fmt"
+
+	"github.com/holoplot/nats-bench/consumer"
 )
 
 type Config struct {
 	NatsURL              string
+	Approach             consumer.Approach
 	NumRealms            int
 	NumConsumers         int
 	NumRealmsPerConsumer int
@@ -13,6 +16,30 @@ type Config struct {
 }
 
 func (c *Config) String() string {
-	return fmt.Sprintf("Realms: %d, Consumers: %d, Realms / Consumer: %d",
-		c.NumRealms, c.NumConsumers, c.NumRealmsPerConsumer)
+	return fmt.Sprintf("Realms: %d, Consumers: %d, Realms / Consumer: %d, Approach: %s",
+		c.NumRealms, c.NumConsumers, c.NumRealmsPerConsumer, c.Approach)
+}
+
+// runConfig returns a Config adjusted for the approach taken
+func (c *Config) runConfig() Config {
+	runConfig := Config{
+		NatsURL:   c.NatsURL,
+		Approach:  c.Approach,
+		Suffixes:  c.Suffixes,
+		NumRealms: c.NumRealms,
+	}
+
+	switch c.Approach {
+	case consumer.MultipleFilterSubjects:
+		runConfig.NumConsumers = c.NumConsumers
+		runConfig.NumRealmsPerConsumer = c.NumRealmsPerConsumer
+	case consumer.ManyConsumers:
+		runConfig.NumConsumers = c.NumConsumers * c.NumRealmsPerConsumer
+		runConfig.NumRealmsPerConsumer = 1
+	case consumer.Wildcard:
+		runConfig.NumConsumers = c.NumConsumers
+		runConfig.NumRealmsPerConsumer = 0
+	}
+
+	return runConfig
 }

--- a/consumer/approach.go
+++ b/consumer/approach.go
@@ -1,0 +1,30 @@
+package consumer
+
+import "fmt"
+
+type Approach string
+
+const (
+	MultipleFilterSubjects = Approach("multiple-filter-subjects")
+	ManyConsumers          = Approach("many-consumers")
+	Wildcard               = Approach("wildcard")
+)
+
+var approaches []Approach
+
+func init() {
+	approaches = []Approach{MultipleFilterSubjects, ManyConsumers, Wildcard}
+}
+
+func Approaches() []Approach {
+	return approaches
+}
+
+func NewApproach(name string) Approach {
+	for _, a := range approaches {
+		if string(a) == name {
+			return a
+		}
+	}
+	panic(fmt.Sprintf("unknown approach: '%s'", name))
+}

--- a/consumer/config.go
+++ b/consumer/config.go
@@ -1,0 +1,44 @@
+package consumer
+
+import (
+	"strings"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+type Config struct {
+	NatsURL  string
+	Stream   string
+	ClientID string
+	Approach Approach
+	Realms   []string
+	Suffixes []string
+}
+
+func (c *Config) consumerConfig() jetstream.OrderedConsumerConfig {
+	config := jetstream.OrderedConsumerConfig{
+		DeliverPolicy: jetstream.DeliverLastPerSubjectPolicy,
+	}
+
+	switch c.Approach {
+	case MultipleFilterSubjects:
+		for _, realm := range c.Realms {
+			subject := strings.Join([]string{"config", realm, ">"}, ".")
+			config.FilterSubjects = append(config.FilterSubjects, subject)
+		}
+	case ManyConsumers:
+		if len(c.Realms) != 1 {
+			panic("only a single realm is allowed with this approach")
+		}
+		subject := strings.Join([]string{"config", c.Realms[0], ">"}, ".")
+		config.FilterSubjects = []string{subject}
+	case Wildcard:
+		if len(c.Realms) != 0 {
+			panic("specifying realms is not allowed with this approach")
+		}
+		subject := "config.*.>"
+		config.FilterSubjects = []string{subject}
+	}
+
+	return config
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
       - NATS_URL=nats:4222
     command:
        - /opt/nats-bench
+       - -approach=${APPROACH:-multiple-filter-subjects}
        - -num-realms=${NUM_REALMS}
        - -num-consumers=${NUM_CONSUMERS}
        - -num-realms-per-consumer=${NUM_REALMS_PER_CONSUMER}

--- a/main.go
+++ b/main.go
@@ -7,15 +7,18 @@ import (
 	"os"
 
 	"github.com/holoplot/nats-bench/client"
+	"github.com/holoplot/nats-bench/consumer"
 )
 
 func main() {
+	approach := flag.String("approach", "multiple-filter-subjects", fmt.Sprintf("One of %v", consumer.Approaches()))
 	numRealms := flag.Int("num-realms", 10000, "Number of items in the config realm")
 	numConsumers := flag.Int("num-consumers", 10, "Number of consumers")
 	numRealmsPerConsumer := flag.Int("num-realms-per-consumer", 10, "Number of subjects each consumer subscribes to")
 	flag.Parse()
 
 	config := client.Config{
+		Approach:             consumer.NewApproach(*approach),
 		NumRealms:            *numRealms,
 		NumConsumers:         *numConsumers,
 		NumRealmsPerConsumer: *numRealmsPerConsumer,


### PR DESCRIPTION
By default the 'multiple-filter-subjects' approach is used as before.

Refer to the README to find out what this means and how to benchmark other approaches.
